### PR TITLE
Make core 0 the default for TCL commands

### DIFF
--- a/tcl/target/rp2040.cfg
+++ b/tcl/target/rp2040.cfg
@@ -39,6 +39,12 @@ set _FLASHBASE 0x10000000
 #          name        driver        base, size in bytes, chip_width, bus_width, target used to access
 flash bank $_FLASHNAME rp2040_flash $_FLASHBASE $_FLASHSIZE    1 32 $_TARGETNAME_0
 
+# Openocd associates a flash bank with a target (in our case a core) and
+# running `openocd -c "program foo.elf"` just grabs the last selected core
+# from the TCL context. Select `core0` by default so that flash probe
+# succeeds. Note gdb understands there are 2 cores -- this is only for TCL.
+targets rp2040.core0
+
 # srst is not fitted so use SYSRESETREQ to perform a soft reset
 reset_config srst_nogate
 


### PR DESCRIPTION
See #6. When you issue a `program` command directly to openocd, it grabs the latest target from the TCL context and checks if it has any flash banks with a matching address. Unfortunately this happens to be core 1, and the flash is associated with core 0. 

I did look around to see if there were any pre-`program` events which we could hook to solve this cleanly, but it seems there aren't. This patch selects core 0 by default in the TCL context by adding a `targets` command to `rp2040.cfg`, so that a `program` command probes the flash successfully.