### PR TITLE
rp2040: add .cfg files for single core targets

### DIFF
--- a/tcl/target/rp2040-core0.cfg
+++ b/tcl/target/rp2040-core0.cfg
@@ -1,0 +1,39 @@
+source [find target/swj-dp.tcl]
+source [find mem_helper.tcl]
+
+set _CHIPNAME rp2040
+set _CPUTAPID 0x01002927
+set _ENDIAN little
+
+swj_newdap $_CHIPNAME.core0 cpu -dp-id $_CPUTAPID -instance-id 0
+
+# NOTE target smp makes both targets act a single virtual target on one port for gdb
+#      (without it you should be able to debug separately on two ports)
+# NOTE: "-rtos hwthread" creates a thread per core in smp mode (otherwise it is a single thread for the virtual target)
+
+# Give OpenOCD SRAM1 (64k) to use for e.g. flash programming bounce buffers (should avoid algo stack etc)
+# Don't require save/restore, because this isn't something we'd do whilst a user app is running
+set _WORKSIZE 0x10000
+set _WORKBASE 0x20010000
+
+#core 0
+set _TARGETNAME_0 $_CHIPNAME.core0
+dap create $_TARGETNAME_0.dap -chain-position $_CHIPNAME.core0.cpu
+target create $_TARGETNAME_0 cortex_m -endian $_ENDIAN -coreid 0 -dap $_TARGETNAME_0.dap -rtos hwthread
+$_TARGETNAME_0 configure -work-area-phys $_WORKBASE -work-area-size $_WORKSIZE -work-area-backup 0
+cortex_m reset_config sysresetreq
+
+target smp $_TARGETNAME_0
+
+set _FLASHNAME $_CHIPNAME.flash
+set _FLASHSIZE 0x200000
+set _FLASHBASE 0x10000000
+#          name        driver        base, size in bytes, chip_width, bus_width, target used to access
+flash bank $_FLASHNAME rp2040_flash $_FLASHBASE $_FLASHSIZE    1 32 $_TARGETNAME_0
+
+# srst is not fitted so use SYSRESETREQ to perform a soft reset
+reset_config srst_nogate
+
+gdb_flash_program enable
+gdb_memory_map enable
+

--- a/tcl/target/rp2040-core1.cfg
+++ b/tcl/target/rp2040-core1.cfg
@@ -1,0 +1,39 @@
+source [find target/swj-dp.tcl]
+source [find mem_helper.tcl]
+
+set _CHIPNAME rp2040
+set _CPUTAPID 0x01002927
+set _ENDIAN little
+
+swj_newdap $_CHIPNAME.core1 cpu -dp-id $_CPUTAPID -instance-id 1
+
+# NOTE target smp makes both targets act a single virtual target on one port for gdb
+#      (without it you should be able to debug separately on two ports)
+# NOTE: "-rtos hwthread" creates a thread per core in smp mode (otherwise it is a single thread for the virtual target)
+
+# Give OpenOCD SRAM1 (64k) to use for e.g. flash programming bounce buffers (should avoid algo stack etc)
+# Don't require save/restore, because this isn't something we'd do whilst a user app is running
+set _WORKSIZE 0x10000
+set _WORKBASE 0x20010000
+
+#core 1
+set _TARGETNAME_1 $_CHIPNAME.core1
+dap create $_TARGETNAME_1.dap -chain-position $_CHIPNAME.core1.cpu
+target create $_TARGETNAME_1 cortex_m -endian $_ENDIAN -coreid 1 -dap $_TARGETNAME_1.dap -rtos hwthread
+$_TARGETNAME_1 configure -work-area-phys $_WORKBASE -work-area-size $_WORKSIZE -work-area-backup 0
+cortex_m reset_config sysresetreq
+
+target smp $_TARGETNAME_1
+
+set _FLASHNAME $_CHIPNAME.flash
+set _FLASHSIZE 0x200000
+set _FLASHBASE 0x10000000
+#          name        driver        base, size in bytes, chip_width, bus_width, target used to access
+flash bank $_FLASHNAME rp2040_flash $_FLASHBASE $_FLASHSIZE    1 32 $_TARGETNAME_1
+
+# srst is not fitted so use SYSRESETREQ to perform a soft reset
+reset_config srst_nogate
+
+gdb_flash_program enable
+gdb_memory_map enable
+


### PR DESCRIPTION
When one of the cores is unavailable to the external SWD port (due to syscfg_hw->DBGFORCE making it unavailable) or one of the cores is acting as the debugger for the other core (virtual SWD interface with just one core), the existing ./tcl/target/rp2040.cfg file doesn't work.

I'm open to a better way of sharing the code between rp2040.cfg and single core variants of this; this PR is primarily to just raise the issue of single core use cases.

Thanks.
