### PR TITLE
Add Raspberry Pi Pico Picoprobe to udev rules

### DIFF
--- a/contrib/60-openocd.rules
+++ b/contrib/60-openocd.rules
@@ -171,4 +171,7 @@ ATTRS{idVendor}=="c251", ATTRS{idProduct}=="2710", MODE="660", GROUP="plugdev", 
 # CMSIS-DAP compatible adapters
 ATTRS{product}=="*CMSIS-DAP*", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
+# Rasberry Pi Pico - Picoprobe
+ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="0004", ATTRS{product}=="Picoprobe", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
 LABEL="openocd_rules_end"


### PR DESCRIPTION
Set correct permissions for the USB device when the device is plugged in.
