### PR TITLE
Exit and enter XIP for erase and write

### DIFF
--- a/src/flash/nor/rp2040.c
+++ b/src/flash/nor/rp2040.c
@@ -172,7 +172,6 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 		return ERROR_TARGET_UNALIGNED_ACCESS;
 	}
 
-	// This is a good place to do this because flash erase always follows a reset init
 	LOG_DEBUG("Connecting internal flash");
 	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_CONNECT_INTERNAL_FLASH, NULL, 0);
 	if (err != ERROR_OK)
@@ -250,7 +249,6 @@ static int rp2040_flash_erase(struct flash_bank *bank, unsigned int first, unsig
 	uint32_t length = bank->sectors[last].offset + bank->sectors[last].size - start_addr;
 	LOG_DEBUG("RP2040 erase %d bytes starting at 0x%08x", length, start_addr);
 
-	// This is a good place to do this because flash erase always follows a reset init
 	LOG_DEBUG("Connecting internal flash");
 	int err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_CONNECT_INTERNAL_FLASH, NULL, 0);
 	if (err != ERROR_OK)

--- a/src/flash/nor/rp2040.c
+++ b/src/flash/nor/rp2040.c
@@ -189,7 +189,7 @@ static int rp2040_flash_enter_xip(struct flash_bank *bank)
 	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_ENTER_CMD_XIP, NULL, 0);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 enter xip: failed enter flash XIP mode");
+		LOG_ERROR("RP2040 enter xip: failed to enter flash XIP mode");
 	}
 	return err;
 }

--- a/src/flash/nor/rp2040.c
+++ b/src/flash/nor/rp2040.c
@@ -210,10 +210,9 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 		return ERROR_TARGET_UNALIGNED_ACCESS;
 	}
 
-	err = rp2040_flash_exit_xip (bank);
+	err = rp2040_flash_exit_xip(bank);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 write: failed to exit flash XIP mode");
 		return err;
 	}
 
@@ -263,11 +262,7 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 		return err;
 	}
 
-	err = rp2040_flash_enter_xip (bank);
-	if (err != ERROR_OK)
-	{
-		LOG_ERROR("RP2040 write: failed to enter flash XIP mode");
-	}
+	err = rp2040_flash_enter_xip(bank);
 
 	return err;
 }
@@ -281,10 +276,9 @@ static int rp2040_flash_erase(struct flash_bank *bank, unsigned int first, unsig
 
 	LOG_DEBUG("RP2040 erase %d bytes starting at 0x%08x", length, start_addr);
 
-	err = rp2040_flash_exit_xip (bank);
+	err = rp2040_flash_exit_xip(bank);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 write: failed to exit flash XIP mode");
 		return err;
 	}
 
@@ -316,11 +310,7 @@ static int rp2040_flash_erase(struct flash_bank *bank, unsigned int first, unsig
 		}
 	}
 
-	err = rp2040_flash_enter_xip (bank);
-	if (err != ERROR_OK)
-	{
-		LOG_ERROR("RP2040 write: failed to enter flash XIP mode");
-	}
+	err = rp2040_flash_enter_xip(bank);
 
 	return err;
 }

--- a/src/flash/nor/rp2040.c
+++ b/src/flash/nor/rp2040.c
@@ -156,6 +156,44 @@ struct rp2040_flash_bank {
 	target_addr_t stacktop;
 };
 
+static int rp2040_flash_exit_xip(struct flash_bank *bank) 
+{
+	struct rp2040_flash_bank *priv = bank->driver_priv;
+	int err = ERROR_OK;
+
+	LOG_DEBUG("Connecting internal flash");
+	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_CONNECT_INTERNAL_FLASH, NULL, 0);
+	if (err != ERROR_OK)
+	{
+		LOG_ERROR("RP2040 exit xip: failed to connect internal flash");
+		return err;
+	}
+
+	LOG_DEBUG("Kicking flash out of XIP mode");
+	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_EXIT_XIP, NULL, 0);
+	if (err != ERROR_OK)
+	{
+		LOG_ERROR("RP2040 exit xip: failed to exit flash XIP mode");
+		return err;
+	}
+
+	return err;
+}
+
+static int rp2040_flash_enter_xip(struct flash_bank *bank) 
+{
+	struct rp2040_flash_bank *priv = bank->driver_priv;
+	int err = ERROR_OK;
+
+	LOG_DEBUG("Configuring SSI for execute-in-place");
+	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_ENTER_CMD_XIP, NULL, 0);
+	if (err != ERROR_OK)
+	{
+		LOG_ERROR("RP2040 enter xip: failed enter flash XIP mode");
+	}
+	return err;
+}
+
 static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, uint32_t offset, uint32_t count)
 {
 	LOG_INFO("Writing %d bytes starting at 0x%x", count, offset);
@@ -172,16 +210,7 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 		return ERROR_TARGET_UNALIGNED_ACCESS;
 	}
 
-	LOG_DEBUG("Connecting internal flash");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_CONNECT_INTERNAL_FLASH, NULL, 0);
-	if (err != ERROR_OK)
-	{
-		LOG_ERROR("RP2040 write: failed to connect internal flash");
-		return err;
-	}
-
-	LOG_DEBUG("Kicking flash out of XIP mode");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_EXIT_XIP, NULL, 0);
+	err = rp2040_flash_exit_xip (bank);
 	if (err != ERROR_OK)
 	{
 		LOG_ERROR("RP2040 write: failed to exit flash XIP mode");
@@ -233,12 +262,13 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 		LOG_ERROR("RP2040 write: failed to flush flash cache");
 		return err;
 	}
-	LOG_DEBUG("Configuring SSI for execute-in-place");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_ENTER_CMD_XIP, NULL, 0);
+
+	err = rp2040_flash_enter_xip (bank);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 write: failed enter flash XIP mode");
+		LOG_ERROR("RP2040 write: failed to enter flash XIP mode");
 	}
+
 	return err;
 }
 
@@ -247,24 +277,16 @@ static int rp2040_flash_erase(struct flash_bank *bank, unsigned int first, unsig
 	struct rp2040_flash_bank *priv = bank->driver_priv;
 	uint32_t start_addr = bank->sectors[first].offset;
 	uint32_t length = bank->sectors[last].offset + bank->sectors[last].size - start_addr;
+	int err = ERROR_OK;
+
 	LOG_DEBUG("RP2040 erase %d bytes starting at 0x%08x", length, start_addr);
 
-	LOG_DEBUG("Connecting internal flash");
-	int err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_CONNECT_INTERNAL_FLASH, NULL, 0);
+	err = rp2040_flash_exit_xip (bank);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 erase: failed to connect internal flash");
+		LOG_ERROR("RP2040 write: failed to exit flash XIP mode");
 		return err;
 	}
-
-	LOG_DEBUG("Kicking flash out of XIP mode");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_EXIT_XIP, NULL, 0);
-	if (err != ERROR_OK)
-	{
-		LOG_ERROR("RP2040 erase: failed to exit flash XIP mode");
-		return err;
-	}
-
 
 	LOG_DEBUG("Remote call flash_range_erase");
 
@@ -294,11 +316,10 @@ static int rp2040_flash_erase(struct flash_bank *bank, unsigned int first, unsig
 		}
 	}
 
-	LOG_DEBUG("Configuring SSI for execute-in-place");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_ENTER_CMD_XIP, NULL, 0);
+	err = rp2040_flash_enter_xip (bank);
 	if (err != ERROR_OK)
 	{
-		LOG_ERROR("RP2040 write: failed enter flash XIP mode");
+		LOG_ERROR("RP2040 write: failed to enter flash XIP mode");
 	}
 
 	return err;


### PR DESCRIPTION
This PR fixes #25 by exiting and entering XIP mode separately for erase and write.

This will allow writing discontinuous flash regions.
