### PR TITLE
tcl/boards: add pico-debug.cfg

### DIFF
--- a/tcl/board/pico-debug.cfg
+++ b/tcl/board/pico-debug.cfg
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# pico-debug is a virtual CMSIS-DAP debug adapter
+# it runs on the very same RP2040 target being debugged without additional hardware
+# https://github.com/majbthrd/pico-debug
+
+source [find interface/cmsis-dap.cfg]
+adapter speed 4000
+
+set CHIPNAME rp2040
+source [find target/rp2040-core0.cfg]


### PR DESCRIPTION
Adopt the RP2040 debugger configuration already in the authentic OpenOCD so that users do not need two sets of instructions depending on whether they use the authentic OpenOCD or the RPI fork.
