### PR TITLE
Always flush cache when entering XIP (see #29)

### DIFF
--- a/src/flash/nor/rp2040.c
+++ b/src/flash/nor/rp2040.c
@@ -185,6 +185,16 @@ static int rp2040_flash_enter_xip(struct flash_bank *bank)
 	struct rp2040_flash_bank *priv = bank->driver_priv;
 	int err = ERROR_OK;
 
+	// Always flush before returning to execute-in-place, to invalidate stale cache contents.
+	// The flush call also restores regular hardware-controlled chip select following a rp2040_flash_exit_xip().
+	LOG_DEBUG("Flushing flash cache after write behind");
+	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_FLUSH_CACHE, NULL, 0);
+	if (err != ERROR_OK)
+	{
+		LOG_ERROR("RP2040 enter xip: failed to flush flash cache");
+		return err;
+	}
+
 	LOG_DEBUG("Configuring SSI for execute-in-place");
 	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_ENTER_CMD_XIP, NULL, 0);
 	if (err != ERROR_OK)
@@ -251,16 +261,6 @@ static int rp2040_flash_write(struct flash_bank *bank, const uint8_t *buffer, ui
 
 	if (err != ERROR_OK)
 		return err;
-
-	// Flash is successfully programmed. We can now do a bit of poking to make the flash
-	// contents visible to us via memory-mapped (XIP) interface in the 0x1... memory region
-	LOG_DEBUG("Flushing flash cache after write behind");
-	err = rp2040_call_rom_func(bank->target, priv->stacktop, FUNC_FLASH_FLUSH_CACHE, NULL, 0);
-	if (err != ERROR_OK)
-	{
-		LOG_ERROR("RP2040 write: failed to flush flash cache");
-		return err;
-	}
 
 	err = rp2040_flash_enter_xip(bank);
 


### PR DESCRIPTION
#29 fixes an important issue, this patch fixes another latent bug which was exposed by #29 (flash cache not being flushed when the flash is erased but not programmed, which can cause bad readback from the debugger)