### PR TITLE
Ignore arguments for JTAG when using SWD.

### DIFF
--- a/src/jtag/tcl.c
+++ b/src/jtag/tcl.c
@@ -625,6 +625,13 @@ static int jim_newtap_cmd(Jim_GetOptInfo *goi)
 					instance_id_specified = true;
 					e = jim_newtap_md_param(n, goi, pTap);
 					break;
+				case NTAP_OPT_EXPECTED_ID:
+				case NTAP_OPT_IRLEN:
+				case NTAP_OPT_IRMASK:
+				case NTAP_OPT_IRCAPTURE:
+					/* dummy read to ignore the next argument */
+					Jim_GetOpt_Wide(goi, NULL);
+					break;
 				default:
 					e = JIM_OK;
 					break;


### PR DESCRIPTION
Fixes #37 potentially.