### PR TITLE
build: remove warnings with gcc 11

### DIFF
--- a/src/flash/nor/numicro.c
+++ b/src/flash/nor/numicro.c
@@ -1243,7 +1243,7 @@ static uint32_t numicro_fmc_cmd(struct target *target, uint32_t cmd, uint32_t ad
 		retval = target_read_u32(target, NUMICRO_FLASH_ISPTRG, &status);
 		if (retval != ERROR_OK)
 			return retval;
-			LOG_DEBUG("status: 0x%" PRIx32 "", status);
+		LOG_DEBUG("status: 0x%" PRIx32 "", status);
 		if ((status & (ISPTRG_ISPGO)) == 0)
 			break;
 		if (timeout-- <= 0) {
@@ -1512,7 +1512,7 @@ static int numicro_erase(struct flash_bank *bank, unsigned int first,
 			retval = target_read_u32(target, NUMICRO_FLASH_ISPTRG, &status);
 			if (retval != ERROR_OK)
 				return retval;
-				LOG_DEBUG("status: 0x%" PRIx32 "", status);
+			LOG_DEBUG("status: 0x%" PRIx32 "", status);
 			if (status == 0)
 				break;
 			if (timeout-- <= 0) {
@@ -1601,7 +1601,7 @@ static int numicro_write(struct flash_bank *bank, const uint8_t *buffer,
 				retval = target_read_u32(target, NUMICRO_FLASH_ISPTRG, &status);
 				if (retval != ERROR_OK)
 					return retval;
-					LOG_DEBUG("status: 0x%" PRIx32 "", status);
+				LOG_DEBUG("status: 0x%" PRIx32 "", status);
 				if (status == 0)
 					break;
 				if (timeout-- <= 0) {

--- a/src/target/arm920t.c
+++ b/src/target/arm920t.c
@@ -245,8 +245,8 @@ static int arm920t_read_cp15_interpreted(struct target *target,
 	uint32_t cp15_opcode, uint32_t address, uint32_t *value)
 {
 	struct arm *arm = target_to_arm(target);
-	uint32_t *regs_p[1];
-	uint32_t regs[2];
+	uint32_t *regs_p[16];
+	uint32_t regs[16];
 	uint32_t cp15c15 = 0x0;
 	struct reg *r = arm->core_cache->reg_list;
 
@@ -295,7 +295,7 @@ int arm920t_write_cp15_interpreted(struct target *target,
 {
 	uint32_t cp15c15 = 0x0;
 	struct arm *arm = target_to_arm(target);
-	uint32_t regs[2];
+	uint32_t regs[16];
 	struct reg *r = arm->core_cache->reg_list;
 
 	/* load value, address into R0, R1 */


### PR DESCRIPTION
This removes some warnings which prevent a successful build with -Werror
which is enabled by default. I'm using gcc 11, so maybe others are not
getting this warnings yet.

In src/flash/nor/numicro.c the debug messages were misleadingly indented.
In src/target/arm920t.c the array size where smaller than expected from
the receiving function.

Change-Id: I66f5c6a63beb9f9416e73b726299297476c884d8
Signed-off-by: Rene Kita <git@rkta.de>
Reviewed-on: http://openocd.zylin.com/6104
Reviewed-by: Jonathan McDowell <noodles-openocd@earth.li>
Tested-by: jenkins
Reviewed-by: Tomas Vanek <vanekt@fbl.cz>
Reviewed-by: Antonio Borneo <borneo.antonio@gmail.com>