### PR TITLE
using cmsis-dap adapter to match latest picoprobe firmware

### DIFF
--- a/tcl/interface/picoprobe.cfg
+++ b/tcl/interface/picoprobe.cfg
@@ -1,3 +1,3 @@
 # Adapter section
-adapter driver picoprobe
+adapter driver cmsis-dap
 adapter speed 5000


### PR DESCRIPTION
When following the guide in Appendix A of the [Getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf) OpenOCD couldn't detect the debugger despite having it flashed with the current build of picoprobe. I had the same issue as described in #71 

I believe it stems from the pico now acting as a CMSIS-DAP device (although I'm not sure about it). 

However, this was not reflected in the interface configuration file. This commit changes the configuration file accordingly. I tested it on Fedora 36 and uploading code to a second Pico W using a picoprobe now works as expected!