### PR TITLE
Adding adapter speed 5000 to target/rp2040.cfg

### DIFF
--- a/tcl/target/rp2040.cfg
+++ b/tcl/target/rp2040.cfg
@@ -51,3 +51,4 @@ reset_config srst_nogate
 gdb_flash_program enable
 gdb_memory_map enable
 
+adapter speed 5000


### PR DESCRIPTION
Following up on issue presented [here](https://github.com/raspberrypi/picoprobe/issues/56). 

This takes a simple approach of wrapping the working existing cmsis-dap.cfg into the existing named raspberrypi-swd.cfg file and adds the `adapter speed 5000` line on top of that. This make the steps in the existing documentation work without issue. In order to move forward without such a wrapper the documentation would have to be modified in MANY places, in addition to adding several steps to cover the use of this in VS Code. I find this to be the cleanest solution. 

If one still wants to modify the adapter speed to deal with long wiring/etc. one can simply overwrite the adapter speed in the raspberrypi-swd.cfg with the `-c "adapter speed 1000"` parameter as discussed in the linked thread above. 