### PR TITLE
FIX: dangling pointer 'home' to 'homepath' may be used & set but not used

### DIFF
--- a/src/flash/nand/davinci.c
+++ b/src/flash/nand/davinci.c
@@ -608,7 +608,7 @@ static int davinci_write_page_ecc4infix(struct nand_device *nand, uint32_t page,
 		oob_size -= 16;
 
 	} while (data_size);
-
+	(void)oob_size;
 	/* the last data and OOB writes included the spare area */
 	return davinci_writepage_tail(nand, NULL, 0);
 }

--- a/src/flash/nor/dsp5680xx_flash.c
+++ b/src/flash/nor/dsp5680xx_flash.c
@@ -56,6 +56,7 @@ static int dsp5680xx_build_sector_list(struct flash_bank *bank)
 		bank->sectors[i].is_erased = -1;
 		bank->sectors[i].is_protected = -1;
 	}
+	(void)offset;
 	LOG_USER("%s not tested yet.", __func__);
 	return ERROR_OK;
 

--- a/src/helper/configuration.c
+++ b/src/helper/configuration.c
@@ -146,6 +146,9 @@ int parse_config_file(struct command_context *cmd_ctx)
 
 char *get_home_dir(const char *append_path)
 {
+#ifdef _WIN32
+	char homepath[MAX_PATH];
+#endif
 	char *home = getenv("HOME");
 
 	if (home == NULL) {
@@ -155,7 +158,6 @@ char *get_home_dir(const char *append_path)
 
 		if (home == NULL) {
 
-			char homepath[MAX_PATH];
 			char *drive = getenv("HOMEDRIVE");
 			char *path = getenv("HOMEPATH");
 			if (drive && path) {
@@ -174,7 +176,7 @@ char *get_home_dir(const char *append_path)
 	if (home == NULL)
 		return home;
 
-	char *home_path;
+	char *home_path = NULL;
 
 	if (append_path)
 		home_path = alloc_printf("%s/%s", home, append_path);


### PR DESCRIPTION
When I try to build this on `MSYS2` environment I catch this error
![image](https://user-images.githubusercontent.com/577872/229277102-cde0dfe0-0cd0-4c19-980f-64bba13ad4c2.png)
My building environment is:
![image](https://user-images.githubusercontent.com/577872/229277161-75949948-f0ec-40d8-ae0a-c1566b89f839.png)

And when build in MacOS
![image](https://user-images.githubusercontent.com/577872/230551127-eb46a7a7-95f8-413a-a118-70a7e26b3f9d.png)
![image](https://user-images.githubusercontent.com/577872/230551162-932dd790-eca2-4e73-a155-588ec322fc87.png)
Configuration
![image](https://user-images.githubusercontent.com/577872/230551227-0584cdc9-0f1d-43d0-91e9-9924b60f180e.png)
Environment is
![image](https://user-images.githubusercontent.com/577872/230551333-6a5423ae-871a-4846-8871-a16c146f5da0.png)
