### PR TITLE
Fix calloc argument order warning/error

### DIFF
--- a/src/jtag/drivers/ulink.c
+++ b/src/jtag/drivers/ulink.c
@@ -1473,7 +1473,7 @@ static int ulink_queue_scan(struct ulink *device, struct jtag_command *cmd)
 
 	/* Allocate TDO buffer if required */
 	if ((type == SCAN_IN) || (type == SCAN_IO)) {
-		tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
+		tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
 
 		if (!tdo_buffer_start)
 			return ERROR_FAIL;


### PR DESCRIPTION
Fixes #101 -  `calloc` warning error returned from line `1476` in `src/jtag/drivers/ulink.c`

# Before fix:

```c
tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
```

# After fix:

```c
tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
```