### PR TITLE
Fix RP2350 rescue config

### DIFF
--- a/tcl/target/rp2350-rescue.cfg
+++ b/tcl/target/rp2350-rescue.cfg
@@ -26,7 +26,7 @@ dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.swd -adiv6
 init
 
 # Set rescue bit
-rp2350.dap apreg 0x80000 0 0x2
+rp2350.dap apreg 0x80000 0 0x80000000
 # Make sure it's there
 rp2350.dap apreg 0x80000 0
 # Clr rescue bit


### PR DESCRIPTION
Need to set and clear bit 31 (RESCUE_RESTART) in the RP_AP CTRL register to reboot with the rescue flag set.