### PR TITLE
fix fatal cmalloc warnings as seen with gcc (SUSE Linux) 14.2.1

### DIFF
--- a/src/flash/nor/ambiqmicro.c
+++ b/src/flash/nor/ambiqmicro.c
@@ -124,7 +124,7 @@ FLASH_BANK_COMMAND_HANDLER(ambiqmicro_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	ambiqmicro_info = calloc(sizeof(struct ambiqmicro_flash_bank), 1);
+	ambiqmicro_info = calloc(1, sizeof(struct ambiqmicro_flash_bank));
 
 	bank->driver_priv = ambiqmicro_info;
 

--- a/src/flash/nor/at91sam7.c
+++ b/src/flash/nor/at91sam7.c
@@ -560,7 +560,7 @@ static int at91sam7_read_part_info(struct flash_bank *bank)
 		if (bnk > 0) {
 			if (!t_bank->next) {
 				/* create a new flash bank element */
-				struct flash_bank *fb = calloc(sizeof(struct flash_bank), 1);
+				struct flash_bank *fb = calloc(1, sizeof(struct flash_bank));
 				if (!fb) {
 					LOG_ERROR("No memory for flash bank");
 					return ERROR_FAIL;
@@ -748,7 +748,7 @@ FLASH_BANK_COMMAND_HANDLER(at91sam7_flash_bank_command)
 		if (bnk > 0) {
 			if (!t_bank->next) {
 				/* create a new bank element */
-				struct flash_bank *fb = calloc(sizeof(struct flash_bank), 1);
+				struct flash_bank *fb = calloc(1, sizeof(struct flash_bank));
 				if (!fb) {
 					LOG_ERROR("No memory for flash bank");
 					return ERROR_FAIL;

--- a/src/flash/nor/kinetis.c
+++ b/src/flash/nor/kinetis.c
@@ -930,7 +930,7 @@ FLASH_BANK_COMMAND_HANDLER(kinetis_flash_bank_command)
 	k_chip = kinetis_get_chip(target);
 
 	if (!k_chip) {
-		k_chip = calloc(sizeof(struct kinetis_chip), 1);
+		k_chip = calloc(1, sizeof(struct kinetis_chip));
 		if (!k_chip) {
 			LOG_ERROR("No memory");
 			return ERROR_FAIL;
@@ -1031,7 +1031,7 @@ static int kinetis_create_missing_banks(struct kinetis_chip *k_chip)
 					 bank_idx - k_chip->num_pflash_blocks);
 		}
 
-		bank = calloc(sizeof(struct flash_bank), 1);
+		bank = calloc(1, sizeof(struct flash_bank));
 		if (!bank)
 			return ERROR_FAIL;
 

--- a/src/flash/nor/max32xxx.c
+++ b/src/flash/nor/max32xxx.c
@@ -87,7 +87,7 @@ FLASH_BANK_COMMAND_HANDLER(max32xxx_flash_bank_command)
 		return ERROR_FLASH_BANK_INVALID;
 	}
 
-	info = calloc(sizeof(struct max32xxx_flash_bank), 1);
+	info = calloc(1, sizeof(struct max32xxx_flash_bank));
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[2], info->flash_size);
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[6], info->flc_base);
 	COMMAND_PARSE_NUMBER(uint, CMD_ARGV[7], info->sector_size);

--- a/src/flash/nor/msp432.c
+++ b/src/flash/nor/msp432.c
@@ -937,7 +937,7 @@ static int msp432_probe(struct flash_bank *bank)
 
 	if (is_main && MSP432P4 == msp432_bank->family_type) {
 		/* Create the info flash bank needed by MSP432P4 variants */
-		struct flash_bank *info = calloc(sizeof(struct flash_bank), 1);
+		struct flash_bank *info = calloc(1, sizeof(struct flash_bank));
 		if (!info)
 			return ERROR_FAIL;
 

--- a/src/flash/nor/stellaris.c
+++ b/src/flash/nor/stellaris.c
@@ -453,7 +453,7 @@ FLASH_BANK_COMMAND_HANDLER(stellaris_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	stellaris_info = calloc(sizeof(struct stellaris_flash_bank), 1);
+	stellaris_info = calloc(1, sizeof(struct stellaris_flash_bank));
 	bank->base = 0x0;
 	bank->driver_priv = stellaris_info;
 

--- a/src/flash/nor/stm32f2x.c
+++ b/src/flash/nor/stm32f2x.c
@@ -1020,7 +1020,7 @@ static int stm32x_probe(struct flash_bank *bank)
 		assert(num_sectors > 0);
 
 		bank->num_sectors = num_sectors;
-		bank->sectors = calloc(sizeof(struct flash_sector), num_sectors);
+		bank->sectors = calloc(num_sectors, sizeof(struct flash_sector));
 
 		if (stm32x_otp_is_f7(bank))
 			bank->size = STM32F7_OTP_SIZE;

--- a/src/jtag/drivers/angie.c
+++ b/src/jtag/drivers/angie.c
@@ -1597,7 +1597,7 @@ static int angie_queue_scan(struct angie *device, struct jtag_command *cmd)
 
 	/* Allocate TDO buffer if required */
 	if (type == SCAN_IN || type == SCAN_IO) {
-		tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
+		tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
 
 		if (!tdo_buffer_start)
 			return ERROR_FAIL;

--- a/src/jtag/drivers/ulink.c
+++ b/src/jtag/drivers/ulink.c
@@ -1473,7 +1473,7 @@ static int ulink_queue_scan(struct ulink *device, struct jtag_command *cmd)
 
 	/* Allocate TDO buffer if required */
 	if ((type == SCAN_IN) || (type == SCAN_IO)) {
-		tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
+		tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
 
 		if (!tdo_buffer_start)
 			return ERROR_FAIL;

--- a/src/target/arc_jtag.c
+++ b/src/target/arc_jtag.c
@@ -298,7 +298,7 @@ static int arc_jtag_read_registers(struct arc_jtag *jtag_info, uint32_t type,
 			ARC_JTAG_READ_FROM_CORE_REG : ARC_JTAG_READ_FROM_AUX_REG);
 	arc_jtag_enque_set_transaction(jtag_info, transaction, TAP_DRPAUSE);
 
-	uint8_t *data_buf = calloc(sizeof(uint8_t), count * 4);
+	uint8_t *data_buf = calloc(count * 4, sizeof(uint8_t));
 
 	arc_jtag_enque_register_rw(jtag_info, addr, data_buf, NULL, count);
 
@@ -498,7 +498,7 @@ int arc_jtag_read_memory(struct arc_jtag *jtag_info, uint32_t addr,
 	if (!count)
 		return ERROR_OK;
 
-	data_buf = calloc(sizeof(uint8_t), count * 4);
+	data_buf = calloc(count * 4, sizeof(uint8_t));
 	arc_jtag_enque_reset_transaction(jtag_info);
 
 	/* We are reading from memory. */


### PR DESCRIPTION
gcc 14 spits out warning `error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument`
This aborts the build due to treating warnings as error.
Easy fix is swapping arguments
