### PR TITLE
Remove "VECTRESET is not supported" on RP2350

### DIFF
--- a/tcl/target/rp2350.cfg
+++ b/tcl/target/rp2350.cfg
@@ -77,3 +77,4 @@ if { $_BOTH_CORES } {
 
 # srst does not exist; use SYSRESETREQ to perform a soft reset
 cortex_m reset_config sysresetreq
+rp2350.dap.core1 cortex_m reset_config sysresetreq


### PR DESCRIPTION
The "cortex_m reset_config sysresetreq" setting in the RP2350.tcl script doesn't seem to set the value for core1, leading to warning messages during successful runs:
````
Warn : [rp2350.dap.core1] VECTRESET is not supported on this Cortex-M core, using SYSRESETREQ instead.
Warn : [rp2350.dap.core1] Set 'cortex_m reset_config sysresetreq'.
````

Explicitly add the setting to the RP2350 config file to silence the warnings.

Fixes #120