### PR TITLE
target: rp2040: ROM API call needs the tag as first argument

### DIFF
--- a/tcl/target/rp2040.cfg
+++ b/tcl/target/rp2040.cfg
@@ -83,9 +83,9 @@ if { $_USE_CORE != 1 } {
 	# srst does not exist; use SYSRESETREQ to perform a soft reset
 	$_TARGETNAME_0 cortex_m reset_config sysresetreq
 
-	# After a rescue reset and fi BOOTSEL is halted connect the flash to enable
+	# After a rescue reset and if BOOTSEL is halted connect the flash to enable
 	# reads from the XIP cached mapping area
-	$_TARGETNAME_0 configure -event reset-init { rp2xxx rom_api_call 0 CX }
+	$_TARGETNAME_0 configure -event reset-init { rp2xxx rom_api_call CX }
 }
 
 # core 1


### PR DESCRIPTION
Also, the flash connect call takes no arguments and returns nothing.