### PR TITLE
target/risc-v: add RTT commands for RISC-V target

### DIFF
--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -27,6 +27,7 @@
 #include "debug_defines.h"
 #include <helper/bits.h>
 #include "field_helpers.h"
+#include "rtt/rtt.h"
 
 /*** JTAG registers. ***/
 
@@ -4879,6 +4880,9 @@ static const struct command_registration riscv_command_handlers[] = {
 	},
 	{
 		.chain = smp_command_handlers
+	},
+	{
+		.chain = rtt_target_command_handlers,
 	},
 	COMMAND_REGISTRATION_DONE
 };


### PR DESCRIPTION
The original patch to add the SEGGER RTT tooling added it only for ARM devices. But now JLink supports RISC-V targets and we can now add the RTT command domain to the RISC-V target. I've tested this on my RISC-V 32-bit chip (Pico 2) and it appears to be working - I was able to communicate with the device using the RTT.
### How to test & result

1. Terminal 1
```
./openocd -f interface/cmsis-dap.cfg -f target/rp2350-riscv.cfg -c "adapter speed 5000"  -c "telnet_port 4445" -c "program /path/to/zephyr.elf verify reset"
```
<img width="513" height="377" alt="image" src="https://github.com/user-attachments/assets/4df46739-32f9-444e-99b8-aeca2f9d4944" />

2. Terminal 2
```
telnet localhost 4445
````
<img width="513" height="380" alt="image" src="https://github.com/user-attachments/assets/70b6fd42-1679-4ffc-b32d-e072ac9f5e5c" />

3. Terminal 3
```
telnet localhost 9090
```
<img width="513" height="75" alt="image" src="https://github.com/user-attachments/assets/b0d04870-b90e-44b8-b114-095abd545869" />